### PR TITLE
Fix NoReverseMatch and restore core styles

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -15,6 +15,8 @@
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
     
+    <link rel="stylesheet" href="{% static 'css/base.css' %}">
+    <link rel="stylesheet" href="{% static 'css/brand.css' %}">
     <link rel="stylesheet" href="{% static 'css/wolvcapital_style_fixed.css' %}">
 
     <!-- Custom CSS -->
@@ -483,13 +485,13 @@
                             <ul class="sub">
                               <li><a href="{% url 'about' %}">About Us</a></li>
                               <li><a href="{% url 'contact' %}">Contact</a></li>
-                              <li><a href="{% url 'risk' %}">Risk Disclosure</a></li>
+                                                            <li><a href="{% url 'risk_disclosure' %}">Risk Disclosure</a></li>
                               <li><a href="{% url 'terms' %}">Terms of Service</a></li>
                               <li><a href="{% url 'privacy' %}">Privacy Policy</a></li>
                             </ul>
                           </li>
-                          <li><a href="{% url 'login' %}">Login</a></li>
-                          <li><a class="btn btn-primary" href="{% url 'signup' %}">Sign Up</a></li>
+                                                    <li><a href="{% url 'account_login' %}">Login</a></li>
+                                                    <li><a class="btn btn-primary" href="{% url 'account_signup' %}">Sign Up</a></li>
                         </ul>
 
                         <!-- mobile hamburger -->
@@ -505,11 +507,11 @@
                           <a href="{% url 'about' %}">About Us</a>
                           <a href="{% url 'contact' %}">Contact</a>
                           <span class="group">Legal</span>
-                          <a href="{% url 'risk' %}">Risk Disclosure</a>
+                                                    <a href="{% url 'risk_disclosure' %}">Risk Disclosure</a>
                           <a href="{% url 'terms' %}">Terms of Service</a>
                           <a href="{% url 'privacy' %}">Privacy Policy</a>
                           <span class="group">Login</span>
-                          <a class="btn btn-primary" href="{% url 'signup' %}">Sign Up</a>
+                                                    <a class="btn btn-primary" href="{% url 'account_signup' %}">Sign Up</a>
                         </div>
                       </nav>
 

--- a/wolvcapital/settings.py
+++ b/wolvcapital/settings.py
@@ -197,6 +197,9 @@ TESTING = any(arg in os.environ.get("PYTEST_CURRENT_TEST", "") for arg in ["::"]
 
 if not DEBUG and not TESTING:
     STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+    # Avoid hard 500s if a static path is referenced but missing in the manifest.
+    # WhiteNoise will fall back to the un-hashed file path instead of raising ValueError.
+    WHITENOISE_MANIFEST_STRICT = False
 
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"


### PR DESCRIPTION
This PR fixes a production 500 caused by NoReverseMatch in the base template and restores expected core stylesheets.\n\nChanges:\n- Replace invalid URL names in base template: 'risk' -> 'risk_disclosure', auth links -> allauth ('account_login', 'account_signup').\n- Add base.css and brand.css links back into base template (tests expect these).\n- Keep brand stylesheet wolvcapital_style_fixed.css.\n- Set WHITENOISE_MANIFEST_STRICT = False to avoid hard 500s on missing manifest entries.\n\nVerification:\n- System check: OK\n- collectstatic: OK\n- Tests: 46 passing\n- Local GET '/' returns 200 with HTML.\n\nFollow-ups:\n- Once all static refs are corrected in prod, consider turning manifest strictness back on.\n